### PR TITLE
bug fixed: redirect users to login page if /auth/oauth2/callback failed

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -310,11 +310,15 @@ OAuth2Strategy.prototype.parseErrorResponse = function(body, status) {
 OAuth2Strategy.prototype._loadUserProfile = function(id_token, done) {
   var self = this;
     
-    var id_tokenArray = id_token.split(".");
+  if (typeof id_token === "undefined" || id_token === null) {
+      // fail the authentication process if the id_token is not returned from Ping
+      return this.fail({ message: 'Authentication Failed.' }, 403);
+  }
+    
+  var id_tokenArray = id_token.split(".");
+  var decodedToken = new Buffer(id_tokenArray[1], 'base64');
         
-    var decodedToken = new Buffer(id_tokenArray[1], 'base64');
-        
-    id_token = JSON.parse(decodedToken);
+  id_token = JSON.parse(decodedToken);
   
   function loadIt() {
     return self.userProfile(id_token, done);


### PR DESCRIPTION
Bug:

If a user go to /auth/oauth2/callback without login, the passport library could not get id_token from Ping. The app will crash because the library tries to split the id_token, which is undefined. To fix this issue, a condition checking is placed in the library to redirect users back to the loggin page if the id_token is undefined. 

***************\* Error Message *****************
GET /auth/oauth2/callback 302 7.268 ms - 0 
at=info method=GET path="/auth/oauth2/callback" host=radiant-citadel-90691.herokuapp.com request_id=1d09b86c-a3d0-48cf-9ac9-e05d4903bee0 fwd="164.144.248.26" dyno=web.1 connect=2ms service=12ms status=302 bytes=321 
/app/node_modules/passport-ping-oauth2/lib/strategy.js:313 
var id_tokenArray = id_token.split("."); 
                            ^ 
  TypeError: Cannot read property 'split' of undefined 
     at OAuth2Strategy._loadUserProfile (/app/node_modules/passport-ping-oauth2/lib/strategy.js:313:33) 
     at /app/node_modules/passport-ping-oauth2/lib/strategy.js:173:14 
     at /app/node_modules/oauth/lib/oauth2.js:195:7 
     at passBackControl (/app/node_modules/oauth/lib/oauth2.js:125:9) 
     at IncomingMessage.<anonymous> (/app/node_modules/oauth/lib/oauth2.js:143:7) 
     at emitNone (events.js:85:20) 
     at IncomingMessage.emit (events.js:179:7) 
     at endReadableNT (_stream_readable.js:913:12) 
     at _combinedTickCallback (node.js:377:13) 
     at process._tickDomainCallback (node.js:425:11) 
