### PR TITLE
Fixes#6: Use accessToken when id_token is not available

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -170,7 +170,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
       function(err, accessToken, refreshToken, params) {
         if (err) { return self.error(self._createOAuthError('Failed to obtain access token', err)); }
         
-        self._loadUserProfile(params.id_token, function(err, profile) {
+        self._loadUserProfile(params.id_token || accessToken, function(err, profile) {
           if (err) { return self.error(err); }
           
           function verified(err, user, info) {


### PR DESCRIPTION
Fixes #6 [When id_token is returned from OAuth - use access token to load user profile]